### PR TITLE
README: Remove install using `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,9 @@ hello
   - [runc](https://github.com/opencontainers/runc)
   - [OPTIONAL] [RootlessKit](https://github.com/rootless-containers/rootlesskit) and [slirp4netns](https://github.com/rootless-containers/slirp4netns) for rootless execution
 
-### Using go
-
-```
-$ go install github.com/ktock/buildg@latest
-```
-
-Optionally install [`buildg.sh`](./extras/buildg.sh) for rootless execution (discussed later).
-
 ### Using make
+
+Go 1.18+ is needed.
 
 ```
 $ git clone https://github.com/ktock/buildg


### PR DESCRIPTION
It's not possible. We'll work on fix this

```
go: github.com/ktock/buildg@latest (in github.com/ktock/buildg@v0.0.0-20220509061444-cd821e27d72a):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.

```