### PR TITLE
Fix `clear` to take breakpoint key instead of line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ COMMANDS:
 
 break, b LINE_NUMBER      set a breakpoint
 breakpoints, bp           list breakpoints
-clear LINE_NUMBER         clear a breakpoint
+clear BREAKPOINT_KEY      clear a breakpoint
 clearall                  clear all breakpoints
 next, n                   proceed to the next line
 continue, c               proceed to the next breakpoint


### PR DESCRIPTION
Currently `clear` takes a line number but this should be fixed to take
breakpiont key becaue futural breakpoint can be keyed by non line number
(e.g. event name like build failure).
