### PR TITLE
exec: allow shell-styled expression

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -29,6 +29,27 @@ RUN echo -n a > /a`, testutil.Mirror("busybox:1.32.0"))
 	}
 }
 
+func TestExecQuotes(t *testing.T) {
+	t.Parallel()
+	dt := fmt.Sprintf(`FROM %s
+RUN echo foo`, testutil.Mirror("busybox:1.32.0"))
+	fmt.Printf(dt)
+	tmpCtx, doneTmpCtx := testutil.NewTempContext(t, dt)
+	defer doneTmpCtx()
+
+	sh := testutil.NewDebugShell(t, tmpCtx)
+	defer sh.Close()
+	sh.Do(execNoTTY(`echo -n "hello world"`)).OutEqual("hello world")
+	sh.Do(execNoTTY(`sh -c "echo -n \"hello world\""`)).OutEqual("hello world")
+	sh.Do(execNoTTY(`sh -c 'echo -n "hello world"'`)).OutEqual("hello world")
+	sh.Do(execNoTTY(`sh -c "echo -n 'hello world'"`)).OutEqual("hello world")
+	sh.Do("c")
+
+	if err := sh.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func execNoTTY(args string) string {
 	return "exec -i=false -t=false " + args
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.6.4
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/moby/buildkit v0.0.0-00010101000000-000000000000
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/errors v0.9.1
@@ -43,7 +44,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/handler.go
+++ b/handler.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 	"sync"
 
+	"github.com/google/shlex"
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/solver/pb"
@@ -162,7 +162,9 @@ func (h *handler) handle(ctx context.Context, info *registeredStatus, locs []*lo
 		if err != nil {
 			return err
 		}
-		if args := strings.Split(ln, " "); len(args) > 0 {
+		if args, err := shlex.Split(ln); err != nil {
+			logrus.WithError(err).Warnf("failed to parse line")
+		} else if len(args) > 0 {
 			cont, err := h.dispatch(ctx, info, locs, args)
 			if err != nil {
 				return err


### PR DESCRIPTION
Allow using shell-styled quoting and escaping

e.g.

```
>>> exec sh -c "echo \"hello world\""
hello world
```