### PR TITLE
Prints all hit breaktpoints on a step

### DIFF
--- a/break_test.go
+++ b/break_test.go
@@ -81,7 +81,7 @@ RUN cat /dummy`, testutil.Mirror("busybox:1.32.0"))
 	defer sh.Close()
 	sh.Do("breakpoints").OutContains("on-fail")
 	sh.Do(execNoTTY("cat /a")).OutEqual("a")
-	sh.Do("c").OutContains("on-fail: caught error process")
+	sh.Do("c").OutContains("Breakpoint[on-fail]")
 
 	sh.Do(execNoTTY("cat /a")).OutEqual("a")
 	sh.Do(execNoTTY("cat /dummy")).OutContains("process execution failed")


### PR DESCRIPTION
```
>>> b 4
>>> bp
[0]: line: Dockerfile:4
[on-fail]: breaks on fail
>>> c
Breakpoint[0]: reached line: Dockerfile:4
Breakpoint[on-fail]: caught error process "/bin/sh -c echo -n c > /" did not complete successfully: exit code: 1
Filename: "Dockerfile"
      1| FROM registry2-buildkit:5000/busybox:1
      2| RUN echo -n a > /a
      3| RUN echo -n b > /a
*=>   4| RUN echo -n c > /
      5| RUN echo -n d > /d
```