### PR TITLE
Enable to reuse cached results

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,8 @@ jobs:
         if [ "${{ matrix.mode }}" == "root" ] ; then
           sudo go test -v ./...
         elif [ "${{ matrix.mode }}" == "rootless" ] ; then
-          TEST_BUILDG_PATH=buildg.sh go test -v ./...
+          mkdir -p ${GITHUB_WORKSPACE}/tmp
+          TEST_BUILDG_PATH=buildg.sh TEST_BUILDG_TMP_DIR=${GITHUB_WORKSPACE}/tmp go test -v ./...
         else
           echo "unknown mode ${{ matrix.mode }}"
           exit 1

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Leveraging the generic features added through the work, this project implements 
   - [list](#list)
   - [exit](#exit)
   - [help](#help)
+- [Global flags](#global-flags)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -192,6 +193,7 @@ Flags:
 - `--image value`: Image to use for debugging stage. Specify `--image` flag for [`exec`](#exec) command in debug shell when use this image.
 - `--secret value` : Secret value exposed to the build. Format: `id=secretname,src=filepath`
 - `--ssh value` : Allow forwarding SSH agent to the build. Format: `default|<id>[=<socket>|<key>[,<key>]]`
+- `--cache-reuse` : Reuse previously cached results. Useful for quickly debugging errored step. But breakpoints on cached steps are ignored (FIXME).
 - `--oci-cni-config-path value`: Path to CNI config file (default: "/etc/buildkit/cni.json")
 - `--oci-cni-binary-path value`: Path to CNI plugin binary dir (default: "/opt/cni/bin")
 - `--rootless`: Enable rootless configuration
@@ -295,3 +297,7 @@ Shows a list of commands or help for one command
 Alias: `h`
 
 Usage: `help [COMMAND]`
+
+## Global flags
+
+- `--root` : Path to the root directory for storing data (e.g. "/var/lib/buildg").

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ktock/buildg/pkg/testutil"
+)
+
+const buildgTestTmpDirEnv = "TEST_BUILDG_TMP_DIR"
+
+func TestCacheReuse(t *testing.T) {
+	t.Parallel()
+	tmpCtx, doneTmpCtx := testutil.NewTempContext(t, fmt.Sprintf(`FROM %s
+RUN echo -n a > /a
+RUN echo -n b > /b
+RUN echo fail > /
+`, testutil.Mirror("busybox:1.32.0")))
+	defer doneTmpCtx()
+
+	tmpRoot, err := os.MkdirTemp(os.Getenv(buildgTestTmpDirEnv), "buildg-test-tmproot")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	sh := testutil.NewDebugShell(t, tmpCtx,
+		testutil.WithGlobalOptions("--root="+tmpRoot),
+		testutil.WithOptions("--cache-reuse"))
+	defer sh.Close()
+	sh.Do("next")
+	sh.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh.Do("next")
+	sh.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh.Do("next")
+	sh.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh.Do("next")
+	if err := sh.Wait(); err == nil {
+		t.Fatal(fmt.Errorf("must fail"))
+	}
+
+	sh2 := testutil.NewDebugShell(t, tmpCtx,
+		testutil.WithGlobalOptions("--root="+tmpRoot),
+		testutil.WithOptions("--cache-reuse"))
+	defer sh2.Close()
+	sh2.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh2.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh2.Do("next")
+	if err := sh2.Wait(); err == nil {
+		t.Fatal(fmt.Errorf("must fail"))
+	}
+
+	tmpOKCtx, doneTmpOKCtx := testutil.NewTempContext(t, fmt.Sprintf(`FROM %s
+RUN echo -n a > /a
+RUN echo -n b > /b
+RUN echo -n ok > /ok
+`, testutil.Mirror("busybox:1.32.0")))
+	defer doneTmpOKCtx()
+	shOK := testutil.NewDebugShell(t, tmpOKCtx,
+		testutil.WithGlobalOptions("--root="+tmpRoot),
+		testutil.WithOptions("--cache-reuse"))
+	defer shOK.Close()
+	shOK.Do(execNoTTY("cat /a")).OutEqual("a")
+	shOK.Do(execNoTTY("cat /b")).OutEqual("b")
+	shOK.Do(execNoTTY("cat /ok")).OutEqual("ok")
+	shOK.Do("next")
+	if err := shOK.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/testutil/debugshell.go
+++ b/pkg/testutil/debugshell.go
@@ -79,11 +79,18 @@ func (o *Output) OutNotContains(s string) *Output {
 }
 
 type options struct {
-	opts []string
-	env  []string
+	opts       []string
+	env        []string
+	globalOpts []string
 }
 
 type DebugShellOption func(*options)
+
+func WithGlobalOptions(globalOpts ...string) DebugShellOption {
+	return func(o *options) {
+		o.globalOpts = append(o.globalOpts, globalOpts...)
+	}
+}
 
 func WithOptions(opts ...string) DebugShellOption {
 	return func(o *options) {
@@ -105,7 +112,7 @@ func NewDebugShell(t *testing.T, buildCtx string, opts ...DebugShellOption) *Deb
 
 	buildgCmd := getBuildgBinary(t)
 	prompt := identity.NewID()
-	args := append(append([]string{"debug"}, gotOpts.opts...), buildCtx)
+	args := append(gotOpts.globalOpts, append(append([]string{"--debug", "debug"}, gotOpts.opts...), buildCtx)...)
 	t.Logf("executing %q with args %+v", buildgCmd, args)
 	cmd := exec.Command(buildgCmd, args...)
 	cmd.Env = append(append(os.Environ(), "BUILDG_PS1"+"="+prompt), gotOpts.env...)


### PR DESCRIPTION
Add `--cache-reuse` option which allows sharing the build cache among invocation of `buildg debug` to make the 2nd-time debugging faster. This is useful to speed up running `buildg` multiple times for debugging an errored step.

Note that breakpoints on cached steps are ignored as of now. Because of this limitation, this feature is optional as of now. We should fix this limitation and make it the default behaviour in the future.

The build data is stored to the default common location (e.g. "/var/lib/buildg/data"). To prune the cache, user can manually remove that directory.

### example

Here we debug a failed step at line 4 (`RUN echo fail > /`).

```Dockerfile
FROM registry2-buildkit:5000/busybox:1
RUN echo foo > /foo
RUN echo bar > /bar
RUN echo fail > /
```

1st time invocation computes all steps and caches the result at a common location.

```console
$ buildg.sh debug --cache-reuse /tmp/ctx2
INFO[2022-05-19T00:08:14Z] storing the build data to "/home/ktock/.local/share/buildg/data". to prune the data, remove that directory manually. 
WARN[2022-05-19T00:08:14Z] using host network as the default            
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 134B done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.1s

#3 [auth] sharing credentials for registry2-buildkit:5000
INFO[2022-05-19T00:08:15Z] debug session started. type "help" for command reference. 
Filename: "Dockerfile"
 =>   1| FROM registry2-buildkit:5000/busybox:1
      2| RUN echo foo > /foo
      3| RUN echo bar > /bar
      4| RUN echo fail > /
(buildg) n
#3 DONE 0.0s

#4 [internal] load metadata for registry2-buildkit:5000/busybox:1
#4 DONE 0.1s

#5 [1/4] FROM registry2-buildkit:5000/busybox:1@sha256:52f431d980baa76878329b68ddb69cb124c25efa6e206d8b0bd797a828f0528e
#5 resolve registry2-buildkit:5000/busybox:1@sha256:52f431d980baa76878329b68ddb69cb124c25efa6e206d8b0bd797a828f0528e done
#5 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0B / 772.81kB 0.2s
n
#5 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 772.81kB / 772.81kB 5.0s done
Filename: "Dockerfile"
      1| FROM registry2-buildkit:5000/busybox:1
 =>   2| RUN echo foo > /foo
      3| RUN echo bar > /bar
      4| RUN echo fail > /
(buildg) n
#5 extracting sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0.0s done
#5 DONE 10.5s

#6 [2/4] RUN echo foo > /foo
#6 DONE 6.9s

#7 [3/4] RUN echo bar > /bar
Filename: "Dockerfile"
      1| FROM registry2-buildkit:5000/busybox:1
      2| RUN echo foo > /foo
 =>   3| RUN echo bar > /bar
      4| RUN echo fail > /
(buildg) n
#7 DONE 1.3s

#8 [4/4] RUN echo fail > /
#0 0.093 /bin/sh: can't create /: Is a directory
Breakpoint[on-fail]: caught error process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
Filename: "Dockerfile"
      1| FROM registry2-buildkit:5000/busybox:1
      2| RUN echo foo > /foo
      3| RUN echo bar > /bar
 =>   4| RUN echo fail > /
(buildg) n
#8 ERROR: process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
------
 > [4/4] RUN echo fail > /:
#0 0.093 /bin/sh: can't create /: Is a directory
------
failed to build: failed to solve: process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
[rootlesskit:child ] error: command [/bin/sh -c rm -f /run/runc; exec buildg debug --cache-reuse /tmp/ctx2] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```

2nd time invocation can reuse the cache and we can quickly debug the errored step (line 4: `RUN echo fail > /`) multiple times.
All breakpoints on the cached steps are ignored and the debug session starts from line 4.

```console
$ buildg.sh debug --cache-reuse /tmp/ctx2
INFO[2022-05-19T00:08:51Z] storing the build data to "/home/ktock/.local/share/buildg/data". to prune the data, remove that directory manually. 
WARN[2022-05-19T00:08:51Z] using host network as the default            
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 134B done
#2 DONE 0.0s

#3 [internal] load metadata for registry2-buildkit:5000/busybox:1
#3 DONE 0.0s

#4 [auth] sharing credentials for registry2-buildkit:5000
#4 DONE 0.0s

#5 [1/4] FROM registry2-buildkit:5000/busybox:1@sha256:52f431d980baa76878329b68ddb69cb124c25efa6e206d8b0bd797a828f0528e
#5 resolve registry2-buildkit:5000/busybox:1@sha256:52f431d980baa76878329b68ddb69cb124c25efa6e206d8b0bd797a828f0528e done
#5 DONE 0.0s

#6 [2/4] RUN echo foo > /foo
#6 CACHED

#7 [3/4] RUN echo bar > /bar
#7 CACHED

#8 [4/4] RUN echo fail > /
#0 0.069 /bin/sh: can't create /: Is a directory
Breakpoint[on-fail]: caught error process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
INFO[2022-05-19T00:08:51Z] debug session started. type "help" for command reference. 
Filename: "Dockerfile"
      1| FROM registry2-buildkit:5000/busybox:1
      2| RUN echo foo > /foo
      3| RUN echo bar > /bar
 =>   4| RUN echo fail > /
(buildg) n
#8 ERROR: process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
------
 > [4/4] RUN echo fail > /:
#0 0.069 /bin/sh: can't create /: Is a directory
------
failed to build: failed to solve: process "/bin/sh -c echo fail > /" did not complete successfully: exit code: 1
[rootlesskit:child ] error: command [/bin/sh -c rm -f /run/runc; exec buildg debug --cache-reuse /tmp/ctx2] exited: exit status 1
[rootlesskit:parent] error: child exited: exit status 1
```
