### PR TITLE
decrease error verbosity

### DIFF
--- a/main.go
+++ b/main.go
@@ -391,7 +391,7 @@ func parseConfig(clicontext *cli.Context) (*config.Config, func(), error) {
 func parseSolveOpt(clicontext *cli.Context) (*client.SolveOpt, error) {
 	buildContext := clicontext.Args().First()
 	if buildContext == "" {
-		return nil, errors.New("context needs to be specified")
+		return nil, fmt.Errorf("context needs to be specified")
 	} else if buildContext == "-" || strings.Contains(buildContext, "://") {
 		return nil, fmt.Errorf("unsupported build context: %q", buildContext)
 	}


### PR DESCRIPTION
Thanks for this tool @ktock , It looks amazing.

Why this PR ?
avoid printing the error stacktrace 

```
root@734a148bfed0:/home/buildg/out# ./buildg debug 
context needs to be specified
main.parseSolveOpt
        /home/buildg/main.go:394
main.debugAction
        /home/buildg/main.go:240
github.com/urfave/cli.HandleAction
        /go/pkg/mod/github.com/urfave/cli@v1.22.9/app.go:524
github.com/urfave/cli.Command.Run
        /go/pkg/mod/github.com/urfave/cli@v1.22.9/command.go:173
github.com/urfave/cli.(*App).Run
        /go/pkg/mod/github.com/urfave/cli@v1.22.9/app.go:277
main.main
        /home/buildg/main.go:70
runtime.main
        /usr/local/go/src/runtime/proc.go:255
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1581
```
Signed-off-by: Fahed DORGAA <fahed.dorgaa@gmail.com>