### PR TITLE
exec: add `--env` and `--workdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Flags:
 - `--init-state`: Execute commands in an initial state of that step (experimental)
 - `--tty`, `-t`: Allocate tty (enabled by default)
 - `-i`: Enable stdin. (FIXME: must be set with tty) (enabled by default)
+- `--env value`, `-e value`: Set environment variables
+- `--workdir value`, `-w value`: Working directory inside the container
 
 ### list
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -31,6 +31,8 @@ RUN echo -n a > /a`, testutil.Mirror("busybox:1.32.0"))
 	sh.Do(execNoTTY("--image cat /debugroot/a")).OutEqual("a")
 	sh.Do(execNoTTY("--image --mountroot=/testdebugroot/rootdir/ cat /testdebugroot/rootdir/a")).OutEqual("a")
 	sh.Do(execNoTTY("--init-state cat /a")).OutContains("process execution failed")
+	sh.Do(execNoTTY("-e MSG=hello -e MSG2=world /bin/sh -c \"echo -n $MSG $MSG2\"")).OutEqual("hello world")
+	sh.Do(execNoTTY("--workdir /tmp /bin/sh -c \"echo -n $(pwd)\"")).OutEqual("/tmp")
 	sh.Do("c")
 
 	if err := sh.Wait(); err != nil {


### PR DESCRIPTION
- --env value, -e value: Set environment variables
- --workdir value, -w value: Working directory inside the container

```console
(buildg) exec --workdir /tmp pwd
/tmp
(buildg) exec --env MSG=hello --env MSG2=world /bin/sh -c "echo $MSG $MSG2"
hello world
```
