### PR TITLE
Remove restriction for instructions to exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ Usage: `continue`
 ### exec
 
 Execute command in the step.
-Only supported on RUN instructions as of now.
 
 Alias: `e`
 

--- a/examples/dap/README.md
+++ b/examples/dap/README.md
@@ -19,7 +19,6 @@ Refer to the VS Code documentation for UI usage: https://code.visualstudio.com/d
 ### exec
 
 Execute command in the step.
-Only supported on RUN instructions as of now.
 
 Alias: `e`
 

--- a/exec.go
+++ b/exec.go
@@ -22,7 +22,7 @@ func execCommand(ctx context.Context, hCtx *handlerContext) cli.Command {
 		UsageText: `exec [OPTIONS] [ARGS...]
 
 If ARGS isn't provided, "/bin/sh" is used by default.
-Only supported on RUN instructions as of now.
+container execution on non-RUN instruction is experimental.
 `,
 		Flags: []cli.Flag{
 			cli.BoolFlag{

--- a/pkg/buildkit/controller.go
+++ b/pkg/buildkit/controller.go
@@ -347,6 +347,9 @@ func (o *debugOpWrapper) getResultMounts(inputs []solver.Result, outputs []solve
 			}
 			execMounts[i] = outputs[m.Output].Clone()
 		}
+		return execInputs, execMounts
+	} else if len(outputs) == 1 {
+		return nil, outputs // If it has only one output, allow inspecting it by mounting this to the root dir.
 	}
-	return execInputs, execMounts
+	return nil, nil
 }

--- a/pkg/dap/dap.go
+++ b/pkg/dap/dap.go
@@ -605,7 +605,7 @@ func (s *Server) execCommand(_ context.Context, hCtx *handlerContext) cli.Comman
 		UsageText: `exec [OPTIONS] [ARGS...]
 
 If ARGS isn't provided, "/bin/sh" is used by default.
-Only supported on RUN instructions as of now.
+container execution on non-RUN instruction is experimental
 `,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
@@ -681,6 +681,11 @@ Only supported on RUN instructions as of now.
 			}
 
 			// Launch container
+			switch hCtx.breakContext.Info.Op.GetOp().(type) {
+			case *pb.Op_Exec:
+			default:
+				s.outputStdoutWriter().Write([]byte("container execution on non-RUN instruction is experimental"))
+			}
 			execCfg := buildkit.ContainerConfig{
 				Info:          hCtx.breakContext.Info,
 				Args:          args,


### PR DESCRIPTION
We've restricted the exec to RUN instructions but we don't need this
restriction.
Non-execOp doesn't have runtime configuration in the Op so we run these
containers with a simple default configuration. User can customize the
configuration using options for `exec` command.

