### PR TITLE
Makefile: statically link binary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,10 @@ jobs:
         go-version: '1.18.x'
     - uses: actions/checkout@v3
     - name: Build all
-      run: make
+      run: |
+        make
+        ls -al ./out/buildg
+        if ldd ./out/buildg ; then echo "buildg must be static binary" ; exit 1 ; fi
 
   test:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,16 @@ CMD=buildg
 PKG=github.com/ktock/buildg
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+GO_EXTRA_LDFLAGS=-extldflags '-static'
 GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/pkg/version.Version=$(VERSION) -X $(PKG)/pkg/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)'
+GO_BUILDTAGS=-tags "osusergo netgo static_build"
 
 all: build
 
 build: buildg
 
 buildg:
-	go build -o $(PREFIX)/buildg $(GO_LD_FLAGS) -v .
+	CGO_ENABLED=0 go build -o $(PREFIX)/buildg $(GO_LD_FLAGS) $(GO_BUILDTAGS) -v .
 
 install:
 	install -D -m 755 $(PREFIX)/buildg $(CMD_DESTDIR)/bin


### PR DESCRIPTION
Fixes: #55

Statically link binaries same as BuildKit https://github.com/moby/buildkit/blob/536c3fedca51112a9af39db3a850d3997766f0b9/Dockerfile#L83