### PR TITLE
[Carry 47] ability to build container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+docs
+extras
+examples

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 on:
   push:
+    branches: [ main ]
     tags:
       - 'v*'
 
 env:
-  GHCR_SLUG: ghcr.io/${{ github.repository }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -83,8 +85,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            ${{ env.GHCR_SLUG }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -103,8 +104,8 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  GHCR_SLUG: ghcr.io/${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -65,3 +68,51 @@ jobs:
           done
         done
         hub release create "${ASSET_FLAGS[@]}" -F ${GITHUB_WORKSPACE}/release-note.txt --draft "${RELEASE_TAG}"
+  
+  containerize:
+    runs-on: ubuntu-20.04
+    name: Containerize
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.GHCR_SLUG }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=buildg
+            org.opencontainers.image.description=Interactive debugger for Dockerfile, with support for IDEs (VS Code, Emacs, Neovim, etc.)
+            org.opencontainers.image.vendor=${{ github.repository_owner }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build image
+        uses: docker/bake-action@v2
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: image-all
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /out
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+ARG GO_VERSION=1.18
+ARG RUNC_VERSION=v1.1.3
+
+# syntax = docker/dockerfile:1.4.0
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS base
+WORKDIR /src
+ENV CGO_ENABLED=0
+COPY go.* .
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.1@sha256:23ca08d120366b31d1d7fad29283181f063b0b43879e1f93c045ca5b548868e9 AS xx
+
+FROM base AS build
+
+COPY --from=xx / /
+
+ARG TARGETPLATFORM
+# https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+  xx-go build -o /out/buildg .
+
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-bullseye AS build-base-debian
+RUN dpkg --add-architecture arm64 && \
+  dpkg --add-architecture amd64 && \
+  apt-get update && \
+  apt-get install -y crossbuild-essential-amd64 crossbuild-essential-arm64 git libbtrfs-dev:amd64 libbtrfs-dev:arm64 libseccomp-dev:amd64 libseccomp-dev:arm64
+
+FROM build-base-debian AS build-runc
+ARG {RUNC_VERSION}
+RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc
+WORKDIR /go/src/github.com/opencontainers/runc
+RUN git checkout ${RUNC_VERSION} && \
+  mkdir -p /out
+ENV CGO_ENABLED=1
+RUN GOARCH=amd64 CC=x86_64-linux-gnu-gcc make static && \
+  cp -a runc /out/runc.amd64
+RUN GOARCH=arm64 CC=aarch64-linux-gnu-gcc make static && \
+  cp -a runc /out/runc.arm64
+
+FROM ubuntu:20.04 AS bin-unix
+
+RUN <<EOF
+  apt-get update
+  apt-get install -y ca-certificates
+EOF
+
+COPY --from=build /out/buildg /
+COPY --from=build-runc /out/runc.${TARGETARCH:-amd64} /usr/local/bin/runc
+
+ENTRYPOINT [ "/buildg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,27 @@
+# syntax = docker/dockerfile:1.4.0
+
 ARG GO_VERSION=1.18
 ARG RUNC_VERSION=v1.1.3
 
-# syntax = docker/dockerfile:1.4.0
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS base
-WORKDIR /src
-ENV CGO_ENABLED=0
-COPY go.* .
+# build buildg
+FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-bullseye AS base
 
-FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.1@sha256:23ca08d120366b31d1d7fad29283181f063b0b43879e1f93c045ca5b548868e9 AS xx
+FROM base AS build-buildg
+ARG TARGETARCH
+ENV GOARCH=${TARGETARCH:-amd64}
+COPY . /go/src/github.com/ktock/buildg
+WORKDIR /go/src/github.com/ktock/buildg
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg/mod \
+  PREFIX=/out/ make
 
-FROM base AS build
-
-COPY --from=xx / /
-
-ARG TARGETPLATFORM
-# https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
-RUN --mount=type=bind,target=. \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-  xx-go build -o /out/buildg .
-
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-bullseye AS build-base-debian
+# build runc
+FROM base AS build-runc
+ARG RUNC_VERSION
 RUN dpkg --add-architecture arm64 && \
   dpkg --add-architecture amd64 && \
   apt-get update && \
-  apt-get install -y crossbuild-essential-amd64 crossbuild-essential-arm64 git libbtrfs-dev:amd64 libbtrfs-dev:arm64 libseccomp-dev:amd64 libseccomp-dev:arm64
-
-FROM build-base-debian AS build-runc
-ARG {RUNC_VERSION}
+  apt-get install -y crossbuild-essential-amd64 crossbuild-essential-arm64 libseccomp-dev:amd64 libseccomp-dev:arm64
 RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc
 WORKDIR /go/src/github.com/opencontainers/runc
 RUN git checkout ${RUNC_VERSION} && \
@@ -38,14 +32,11 @@ RUN GOARCH=amd64 CC=x86_64-linux-gnu-gcc make static && \
 RUN GOARCH=arm64 CC=aarch64-linux-gnu-gcc make static && \
   cp -a runc /out/runc.arm64
 
-FROM ubuntu:20.04 AS bin-unix
-
-RUN <<EOF
-  apt-get update
-  apt-get install -y ca-certificates
-EOF
-
-COPY --from=build /out/buildg /
+# create buildg container
+FROM ubuntu:20.04
+ARG TARGETARCH
+RUN apt-get update && apt-get install -y ca-certificates git
+COPY --from=build-buildg /out/buildg /
 COPY --from=build-runc /out/runc.${TARGETARCH:-amd64} /usr/local/bin/runc
-
+VOLUME /var/lib/buildg
 ENTRYPOINT [ "/buildg"]

--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ $ sudo make install
 $ nerdctl builder debug /path/to/build/context
 ```
 
+### Docker
+
+You can run buildg inside Docker.
+You need to bind mount the build context to the container.
+
+```
+docker build -t buildg .
+docker run --rm -it --privileged -v /path/to/ctx:/ctx:ro buildg debug /ctx
+```
+
+You can also use [bake command by Docker Buildx](https://docs.docker.com/engine/reference/commandline/buildx_bake/):
+
+```
+docker buildx bake --set image-local.tags=buildg
+```
+
+> Tip: `--cache-reuse` experimental option + the volume at the buildg root enables to reuse cache among invocations and can speed up 2nd-time debugging.
+> 
+> ```
+> docker run --rm -it --privileged \
+>   -v buildg-cache:/var/lib/buildg \
+>   -v /path/to/ctx:/ctx:ro \
+>   buildg debug --cache-reuse /ctx
+> ```
+
 ## Motivation
 
 Debugging a large and complex Dockerfile isn't easy and can take a long time.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,34 @@
+variable "GO_VERSION" {
+  default = "1.18"
+}
+
+target "_common" {
+  args = {
+    GO_VERSION = GO_VERSION
+  }
+}
+
+// Special target: https://github.com/docker/metadata-action#bake-definition
+target "docker-metadata-action" {}
+
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["_common", "docker-metadata-action"]
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
carrying #47 

Thanks to @developer-guy 

## usage

You can run buildg inside Docker.
You need to bind mount the build context to the container.

```
docker build -t buildg .
docker run --rm -it --privileged -v /path/to/ctx:/ctx:ro buildg debug /ctx
```

You can also use [bake command by Docker Buildx](https://docs.docker.com/engine/reference/commandline/buildx_bake/):

```
docker buildx bake --set image-local.tags=buildg
```
