### PR TITLE
Bump up golangci-lint to v1.49

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.47
+        version: v1.49
         args: --verbose
 
   project:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt


### PR DESCRIPTION
Also removes deprecated linters (`varcheck`, `structcheck`) https://github.com/golangci/golangci-lint/pull/3125