### PR TITLE
Add log command to show build logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Leveraging the generic features added through the work, this project implements 
   - [continue](#continue)
   - [exec](#exec)
   - [list](#list)
+  - [log](#log)
   - [exit](#exit)
   - [help](#help)
 - [Global flags](#global-flags)
@@ -378,6 +379,17 @@ Flags:
 - `-A value`: Print the specified number of lines after the current line (default: 3)
 - `-B value`: Print the specified number of lines before the current line (default: 3)
 - `--range value`: Print the specified number of lines before and after the current line (default: 3)
+
+### log
+
+Show build log
+
+Usage: `log [OPTIONS]`
+
+Flags:
+- `-n value`: Print recent n lines (default: 10)
+- `--all`, `-a`: show all lines
+- `--more`: show buffered and unread lines
 
 ### exit
 

--- a/log.go
+++ b/log.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/urfave/cli"
+)
+
+func logCommand(ctx context.Context, hCtx *handlerContext) cli.Command {
+	return cli.Command{
+		Name:      "log",
+		Usage:     "show build log",
+		UsageText: "log [OPTIONS]",
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "n",
+				Usage: "Print recent n lines",
+				Value: 10,
+			},
+			cli.BoolFlag{
+				Name:  "all,a",
+				Usage: "show all lines",
+			},
+			cli.BoolFlag{
+				Name:  "more",
+				Usage: "show buffered and unread lines",
+			},
+		},
+		Action: func(clicontext *cli.Context) error {
+			if clicontext.Bool("more") {
+				_, err := io.Copy(hCtx.stdout, hCtx.progress.buffered())
+				return err
+			}
+			r, err := hCtx.progress.reader()
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			if clicontext.Bool("all") {
+				_, err := io.Copy(hCtx.stdout, r)
+				return err
+			}
+			n := clicontext.Int("n")
+			if n <= 0 {
+				return nil
+			}
+
+			buf := make([]string, n)
+			cur := 0
+			total := 0
+			scanner := bufio.NewScanner(r)
+			for scanner.Scan() {
+				s := scanner.Text()
+				buf[cur] = s
+				cur++
+				total++
+				if cur >= len(buf) {
+					cur = 0
+				}
+			}
+			if total <= n {
+				for i := 0; i < total; i++ {
+					fmt.Fprintf(hCtx.stdout, "%s\n", buf[i])
+				}
+				return nil
+			}
+			for i := 0; i < n; i++ {
+				fmt.Fprintf(hCtx.stdout, "%s\n", buf[cur])
+				cur++
+				if cur >= len(buf) {
+					cur = 0
+				}
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
### log

Show build log

Usage: `log [OPTIONS]`

Flags:
- `-n value`: Print recent n lines (default: 10)
- `--all`, `-a`: show all lines
- `--more`: show buffered and unread lines

```console
$ buildg.sh debug /tmp/ctx
WARN[2022-08-30T11:22:53+09:00] using host network as the default            
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 111B done
#2 DONE 0.1s

#3 [internal] load metadata for ghcr.io/stargz-containers/busybox:1.32.0-org
#3 ...

#4 [auth] stargz-containers/busybox:pull token for ghcr.io
#4 DONE 0.0s

#3 [internal] load metadata for ghcr.io/stargz-containers/busybox:1.32.0-org
#3 DONE 1.1s
INFO[2022-08-30T11:22:55+09:00] debug session started. type "help" for command reference. 
Filename: "Dockerfile"
 =>   1| FROM ghcr.io/stargz-containers/busybox:1.32.0-org
      2| RUN echo hello > /hello
(buildg) log
#3 ...

#4 [auth] stargz-containers/busybox:pull token for ghcr.io
#4 DONE 0.0s

#3 [internal] load metadata for ghcr.io/stargz-containers/busybox:1.32.0-org
#3 DONE 1.1s

#5 [1/2] FROM ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678
#5 resolve ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678 0.0s done
(buildg) log -more

#5 [1/2] FROM ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678
#5 resolve ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678 0.0s done
(buildg) log -n 5
#3 [internal] load metadata for ghcr.io/stargz-containers/busybox:1.32.0-org
#3 DONE 1.1s

#5 [1/2] FROM ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678
#5 resolve ghcr.io/stargz-containers/busybox:1.32.0-org@sha256:bde48e1751173b709090c2539fdf12d6ba64e88ec7a4301591227ce925f3c678 0.0s done
```