### PR TITLE
Allow to specify the target breakpoint on continue command

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,14 @@ Usage: `next`
 
 ### continue
 
-Proceed to the next breakpoint
+Proceed to the next or the specified breakpoint
 
 Alias: `c`
 
-Usage: `continue`
+Usage: `continue [BREAKPOINT_KEY]`
+
+Optional arg `BREAKPOINT_KEY` is the key of a breakpoint until which continue the build.
+Use `breakpoints` command to list all registered breakpoints.
 
 ### exec
 

--- a/break.go
+++ b/break.go
@@ -110,11 +110,22 @@ func nextCommand(ctx context.Context, hCtx *handlerContext) cli.Command {
 
 func continueCommand(ctx context.Context, hCtx *handlerContext) cli.Command {
 	return cli.Command{
-		Name:      "continue",
-		Aliases:   []string{"c"},
-		Usage:     "Proceed to the next breakpoint",
-		UsageText: "continue",
+		Name:    "continue",
+		Aliases: []string{"c"},
+		Usage:   "Proceed to the next or the specified breakpoint",
+		UsageText: `continue [BREAKPOINT_KEY]
+
+Optional arg BREAKPOINT_KEY is the key of a breakpoint until which continue the build.
+Use "breakpoints" command to list all registered breakpoints.
+`,
 		Action: func(clicontext *cli.Context) error {
+			bp := clicontext.Args().First()
+			if bp != "" {
+				if _, ok := hCtx.handler.Breakpoints().Get(bp); !ok {
+					return fmt.Errorf("unknown breakpoint %v", bp)
+				}
+				hCtx.targetBreakpoint = bp
+			}
 			hCtx.handler.BreakEachVertex(false)
 			hCtx.continueRead = false
 			return nil

--- a/break_test.go
+++ b/break_test.go
@@ -44,6 +44,48 @@ RUN echo -n d > /d`, testutil.Mirror("busybox:1.32.0"))
 	}
 }
 
+func TestBreakpointContinue(t *testing.T) {
+	t.Parallel()
+	dt := fmt.Sprintf(`FROM %s
+RUN echo -n a > /a
+RUN echo -n b > /b
+RUN echo -n c > /c
+RUN echo -n d > /d
+RUN echo -n e > /e`, testutil.Mirror("busybox:1.32.0"))
+	fmt.Println(dt)
+	tmpCtx, doneTmpCtx := testutil.NewTempContext(t, dt)
+	defer doneTmpCtx()
+
+	sh := testutil.NewDebugShell(t, tmpCtx)
+	defer sh.Close(t)
+	sh.Do("b 2")     // breakpoint 0
+	sh.Do("b 3")     // breakpoint 1
+	sh.Do("break 5") // breakpoint 2
+	sh.Do("breakpoints").OutContains("line: Dockerfile:2").OutContains("line: Dockerfile:3").OutContains("line: Dockerfile:5")
+	sh.Do("c 1").OutContains("reached line: Dockerfile:3")
+	sh.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh.Do(execNoTTY("cat /c")).OutContains("process execution failed")
+	sh.Do(execNoTTY("cat /d")).OutContains("process execution failed")
+	sh.Do(execNoTTY("cat /e")).OutContains("process execution failed")
+	sh.Do("c")
+	sh.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh.Do(execNoTTY("cat /c")).OutEqual("c")
+	sh.Do(execNoTTY("cat /d")).OutEqual("d")
+	sh.Do(execNoTTY("cat /e")).OutContains("process execution failed")
+	sh.Do("n")
+	sh.Do(execNoTTY("cat /a")).OutEqual("a")
+	sh.Do(execNoTTY("cat /b")).OutEqual("b")
+	sh.Do(execNoTTY("cat /c")).OutEqual("c")
+	sh.Do(execNoTTY("cat /d")).OutEqual("d")
+	sh.Do(execNoTTY("cat /e")).OutEqual("e")
+	sh.Do("c")
+	if err := sh.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBreakpointNonExec(t *testing.T) {
 	t.Parallel()
 	dt := fmt.Sprintf(`FROM %s AS base


### PR DESCRIPTION
### continue

Proceed to the next or the specified breakpoint

Usage: `continue [BREAKPOINT_KEY]`

Optional arg `BREAKPOINT_KEY` is the key of a breakpoint until which continue the build.
Use `breakpoints` command to list all registered breakpoints.