### PR TITLE
Remove `.m` suffix from release binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
-docs
-examples
 out


### PR DESCRIPTION
We shouldn't have the suffix  `.m` in the released binary like the following:

```
$ buildg --version
buildg version v0.4.0.m
```
