### PR TITLE
chore: use cache-to & cache-from options with GHA mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          bake-target: meta-helper
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -119,6 +120,8 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
-          targets: image-all
-          pull: true
+          targets: image-cross
           push: ${{ github.event_name != 'pull_request' }}
+          set: |
+            *.cache-from=type=gha,scope=bin-image
+            *.cache-to=type=gha,scope=bin-image,mode=max

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,7 +9,7 @@ target "_common" {
 }
 
 // Special target: https://github.com/docker/metadata-action#bake-definition
-target "docker-metadata-action" {}
+target "meta-helper" {}
 
 
 group "default" {
@@ -17,7 +17,8 @@ group "default" {
 }
 
 target "image" {
-  inherits = ["_common", "docker-metadata-action"]
+  inherits = ["_common", "meta-helper"]
+    output = ["type=image"]
 }
 
 target "image-local" {
@@ -25,7 +26,7 @@ target "image-local" {
   output = ["type=docker"]
 }
 
-target "image-all" {
+target "image-cross" {
   inherits = ["image"]
   platforms = [
     "linux/amd64",


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

use [gha cache](https://github.com/moby/buildkit#github-actions-cache-experimental) for speeding up the containerize process

https://github.com/developer-guy/buildg/actions/runs/3050865102
![Screen Shot 2022-09-14 at 10 41 26 AM](https://user-images.githubusercontent.com/16693043/190092275-e6ea67c6-9c8f-4525-a45c-bbdeb000440a.png)
![Screen Shot 2022-09-14 at 10 40 54 AM](https://user-images.githubusercontent.com/16693043/190092283-9dd0d8b5-0675-4514-adfe-a2babc8089c6.png)

/cc @ktock 