### PR TITLE
ci: release: migrate `hub` to `gh`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,6 @@ jobs:
         FULL_TAR=$(ls -1 ${OUTPUT_DIR} | grep buildg-full | head -1)
         FULL_TAR_LIST=$(tar --list -vvf ${OUTPUT_DIR}/${FULL_TAR})
         cat <<EOF > ${GITHUB_WORKSPACE}/release-note.txt
-        ${RELEASE_TAG}
-
         (TBD)
 
         ## About the binaries
@@ -71,10 +69,7 @@ jobs:
         EOF
         ASSET_FLAGS=()
         ls -al ${OUTPUT_DIR}/
-        for F in ${OUTPUT_DIR}/* ; do
-          ASSET_FLAGS+=("-a" "$F")
-        done
-        hub release create "${ASSET_FLAGS[@]}" -F ${GITHUB_WORKSPACE}/release-note.txt --draft "${RELEASE_TAG}"
+        gh release create -F ${GITHUB_WORKSPACE}/release-note.txt --draft --title "${RELEASE_TAG}" "${RELEASE_TAG}" ${OUTPUT_DIR}/*
   
   containerize:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
hub has been deprecated: https://github.com/actions/runner-images/issues/8362