### PR TITLE
Fix install command. Needs name of file in case building in a sandbox.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ buildg:
 	CGO_ENABLED=0 go build -o $(PREFIX)/buildg $(GO_LD_FLAGS) $(GO_BUILDTAGS) -v .
 
 install:
-	install -D -m 755 $(PREFIX)/buildg $(CMD_DESTDIR)/bin
+	install -D -m 755 $(PREFIX)/buildg $(CMD_DESTDIR)/bin/buildg
 
 artifacts: clean
 	GOOS=linux GOARCH=amd64 make buildg


### PR DESCRIPTION
Building in a sandbox is common in many package systems. Install will often be installing into an empty folder. In this case install would create a file at say /usr/bin if CMD_DESTDIR were set to /usr, new version will create the /usr/bin directory and put the buildg file within the /usr/bin/buildg (the desired effect).