### PR TITLE
chore: bump remaining go 1.22 references to 1.23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - uses: actions/checkout@v4
     - name: Build all
       run: |
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - uses: actions/checkout@v4
     - name: Rootlesskit setup
       run: |
@@ -81,7 +81,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22.x'
+        go-version: '1.23.x'
     - uses: actions/checkout@v4
       with:
         fetch-depth: 100

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG ROOTLESSKIT_VERSION=v2.3.4
 ARG SLIRP4NETNS_VERSION=v1.3.2
 
 # Images
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 
 # build buildg
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-bookworm AS base

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ They are included in our release tar `buildg-full-<version>-<os>-<arch>.tar.gz` 
 
 ### Building binary using make
 
-Go 1.18+ is needed.
+Go 1.23+ is needed.
 
 ```
 $ git clone https://github.com/ktock/buildg

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-  default = "1.22"
+  default = "1.23"
 }
 
 target "_common" {

--- a/exec_test.go
+++ b/exec_test.go
@@ -23,7 +23,7 @@ RUN echo -n a > /a`, testutil.Mirror("busybox:1.32.0"))
 	tmpCtx, doneTmpCtx := testutil.NewTempContext(t, dt)
 	defer doneTmpCtx()
 
-	sh := testutil.NewDebugShell(t, tmpCtx, testutil.WithOptions("--image="+testutil.Mirror("ubuntu:22.04")))
+	sh := testutil.NewDebugShell(t, tmpCtx, testutil.WithOptions("--image="+testutil.Mirror("ubuntu:24.04")))
 	defer sh.Close(t)
 	sh.Do("next")
 	sh.Do(execNoTTY("cat /a")).OutEqual("a")
@@ -53,7 +53,7 @@ RUN cat /b
 	tmpCtx, doneTmpCtx := testutil.NewTempContext(t, dt)
 	defer doneTmpCtx()
 
-	sh := testutil.NewDebugShell(t, tmpCtx, testutil.WithOptions("--image="+testutil.Mirror("ubuntu:22.04")))
+	sh := testutil.NewDebugShell(t, tmpCtx, testutil.WithOptions("--image="+testutil.Mirror("ubuntu:24.04")))
 	defer sh.Close(t)
 	sh.Do(execNoTTY("cat /a")).OutContains("process execution failed")
 	sh.Do("next")

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ktock/buildg
 
 go 1.23.0
 
-toolchain go1.23.2
+toolchain go1.23.8
 
 require (
 	github.com/containerd/console v1.0.4


### PR DESCRIPTION
### Changes
- Bump the remaining Go 1.22 references to 1.23
- Update toolchain to 1.23.8
- Update Docker images in tests to use ubuntu:24.04
- Update required Go version in README