### PR TITLE
CI: Fix "containerize" CI to work on the latest bake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          bake-target: meta-helper
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -112,7 +111,7 @@ jobs:
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            cwd://${{ steps.meta.outputs.bake-file }}
           targets: image-cross
           push: ${{ github.event_name != 'pull_request' }}
           set: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         ( cd ${OUTPUT_DIR}; sha256sum * ) > "${GITHUB_WORKSPACE}/SHA256SUMS"
         mv "${GITHUB_WORKSPACE}/SHA256SUMS" "${OUTPUT_DIR}/SHA256SUMS"
     - name: Create Release
+      if: github.event_name != 'pull_request'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -9,7 +9,7 @@ target "_common" {
 }
 
 // Special target: https://github.com/docker/metadata-action#bake-definition
-target "meta-helper" {}
+target "docker-metadata-action" {}
 
 
 group "default" {
@@ -17,7 +17,7 @@ group "default" {
 }
 
 target "image" {
-  inherits = ["_common", "meta-helper"]
+  inherits = ["_common", "docker-metadata-action"]
     output = ["type=image"]
 }
 


### PR DESCRIPTION
v0.5.0 release failed because of this. Let's skip v0.5.0 and release v0.5.1 soon.
https://github.com/ktock/buildg/actions/runs/14663800600/job/41153836282