### PR TITLE
CI: bump up golangci-lint-action to v8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,9 +70,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.0
+        version: v2.1
         args: --verbose
 
   project:


### PR DESCRIPTION
- https://github.com/ktock/buildg/pull/257